### PR TITLE
Added 'rape' to denylist.txt

### DIFF
--- a/denylist.txt
+++ b/denylist.txt
@@ -351,6 +351,7 @@ queerz
 qweers
 qweerz
 qweir
+rape
 rautenberg
 recktum
 rectum


### PR DESCRIPTION
While trying to type 'hello world', the phrase 'hel' uses the word 'rape' in encryption.
The full output is:
sterile october solemnly collect willing voice
colonial tokyo inevitably rape academic comparison
progressive congress similarly perpetrate special avenue
porous lewis briefly appraise continental toast

Also, why is 'russian' on this list?!